### PR TITLE
Various config option additions

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -8,28 +8,49 @@
 #     }
 #
 define dovecot::file (
-    $owner   = 'root',
-    $group   = 'root',
-    $mode    = '0644',
-    $content = undef,
-    $source  = undef
+    $owner    = 'root',
+    $group    = 'root',
+    $mode     = '0644',
+    $content  = undef,
+    $source   = undef,
+    $template = undef,
+    $config   = {},
 ) {
     case $::operatingsystem {
-      'FreeBSD': { $directory = '/usr/local/etc/dovecot' }
-      default:   { $directory = '/etc/dovecot' }
+        'FreeBSD': { $directory = '/usr/local/etc/dovecot' }
+        default:   { $directory = '/etc/dovecot' }
+    }
+
+    if $source and $content {
+        fail('dovecot::file: source or content can be provided, but not both')
+    }
+
+    if $source and $template {
+        fail('dovecot::file: source or template can be provided, but not both')
+    }
+
+    if $content and $template {
+        fail('dovecot::file: content or template can be provided, but not both')
+    }
+
+    if $content {
+        $the_content = $content
+    } elsif $template {
+        $the_content = template($template)
+    } else {
+        $the_content = undef
     }
 
     file { "${directory}/${title}":
         owner   => $owner,
         group   => $group,
         mode    => $mode,
-        content => $content,
+        content => $the_content,
         source  => $source,
         require => Package[$dovecot::packages],
         replace => true,
     }
     if $dovecot::manage_service {
-      File["/etc/dovecot/${title}"] ~> Service['dovecot']
+        File["/etc/dovecot/${title}"] ~> Service['dovecot']
     }
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,138 +6,145 @@
 #    Array of plugin sub-packages to install. Default: empty
 #
 class dovecot (
-    $plugins                    = [],
+    $plugins                      = [],
     # dovecot.conf
-    $protocols                  = undef,
-    $listen                     = undef,
-    $login_greeting             = undef,
-    $login_trusted_networks     = undef,
-    $verbose_proctitle          = undef,
-    $shutdown_clients           = undef,
+    $protocols                    = undef,
+    $listen                       = undef,
+    $login_greeting               = undef,
+    $login_trusted_networks       = undef,
+    $verbose_proctitle            = undef,
+    $shutdown_clients             = undef,
     # 10-auth.conf
-    $disable_plaintext_auth     = undef,
-    $auth_username_chars        = undef,
-    $auth_mechanisms            = 'plain',
-    $auth_include               = [ 'system' ],
+    $disable_plaintext_auth       = undef,
+    $auth_username_chars          = undef,
+    $auth_username_format         = undef,
+    $auth_mechanisms              = 'plain',
+    $auth_include                 = [ 'system' ],
     # 10-logging.conf
-    $log_path                   = undef,
-    $log_timestamp              = undef,
-    $auth_verbose               = undef,
-    $auth_debug                 = undef,
-    $mail_debug                 = undef,
+    $log_path                     = undef,
+    $log_timestamp                = undef,
+    $debug_log_path               = undef,
+    $info_log_path                = undef,
+    $auth_verbose                 = undef,
+    $auth_debug                   = undef,
+    $mail_debug                   = undef,
     # 10-mail.conf
-    $mail_home                  = undef,
-    $mail_fsync                 = undef,
-    $mail_location              = undef,
-    $mail_uid                   = undef,
-    $mail_gid                   = undef,
-    $mail_nfs_index             = undef,
-    $mail_nfs_storage           = undef,
-    $mail_privileged_group      = undef,
-    $mail_plugins               = undef,
-    $mmap_disable               = undef,
-    $dotlock_use_excl           = undef,
-    $include_inbox_namespace    = undef,
+    $mail_home                    = undef,
+    $mail_fsync                   = undef,
+    $mail_location                = undef,
+    $mail_uid                     = undef,
+    $mail_gid                     = undef,
+    $mail_nfs_index               = undef,
+    $mail_nfs_storage             = undef,
+    $mail_privileged_group        = undef,
+    $mail_plugins                 = undef,
+    $mmap_disable                 = undef,
+    $dotlock_use_excl             = undef,
+    $include_inbox_namespace      = undef,
+    $custom_namespaces            = {},
     # 10-master.conf
-    $default_process_limit      = undef,
-    $default_client_limit       = undef,
-    $auth_listener_userdb_mode   = undef,
-    $auth_listener_userdb_user   = undef,
-    $auth_listener_userdb_group  = undef,
-    $auth_listener_postfix       = false,
-    $auth_listener_postfix_mode  = undef,
-    $auth_listener_postfix_user  = undef,
-    $auth_listener_postfix_group = undef,
-    $imap_login_process_limit   = undef,
-    $imap_login_client_limit    = undef,
-    $imap_login_service_count   = undef,
+    $default_process_limit        = undef,
+    $default_client_limit         = undef,
+    $auth_listener_userdb_mode    = undef,
+    $auth_listener_userdb_user    = undef,
+    $auth_listener_userdb_group   = undef,
+    $auth_listener_postfix        = false,
+    $auth_listener_postfix_mode   = undef,
+    $auth_listener_postfix_user   = undef,
+    $auth_listener_postfix_group  = undef,
+    $imap_login_process_limit     = undef,
+    $imap_login_client_limit      = undef,
+    $imap_login_service_count     = undef,
     $imap_login_process_min_avail = undef,
-    $imap_login_vsz_limit       = undef,
-    $pop3_login_service_count   = undef,
+    $imap_login_vsz_limit         = undef,
+    $enable_pop3                  = true,
+    $pop3_login_service_count     = undef,
     $pop3_login_process_min_avail = undef,
-    $default_vsz_limit          = undef,
-    $auth_listener_default_user = undef,
-    $imaplogin_imap_port         = 0,
-    $imaplogin_imaps_port        = 0,
-    $imaplogin_imaps_ssl         = false,
-    $lmtp_unix_listener          = undef,
-    $lmtp_unix_listener_mode     = undef,
-    $lmtp_unix_listener_user     = undef,
-    $lmtp_unix_listener_group    = undef,
-    $lmtp_socket_group          = undef,
-    $lmtp_socket_mode           = undef,
-    $lmtp_socket_path           = undef,
-    $lmtp_socket_user           = undef,
+    $default_vsz_limit            = undef,
+    $auth_listener_default_user   = undef,
+    $imaplogin_imap_port          = -1,
+    $imaplogin_imaps_port         = -1,
+    $imaplogin_imaps_ssl          = false,
+    $lmtp_unix_listener           = undef,
+    $lmtp_unix_listener_mode      = undef,
+    $lmtp_unix_listener_user      = undef,
+    $lmtp_unix_listener_group     = undef,
+    $lmtp_socket_group            = undef,
+    $lmtp_socket_mode             = undef,
+    $lmtp_socket_path             = undef,
+    $lmtp_socket_user             = undef,
     # 10-ssl.conf
-    $ssl                        = undef,
-    $ssl_cert                   = '/etc/pki/dovecot/certs/dovecot.pem',
-    $ssl_key                    = '/etc/pki/dovecot/private/dovecot.pem',
-    $ssl_cipher_list            = undef,
-    $ssl_protocols              = undef,
-    $ssl_dh_parameters_length   = undef,
+    $ssl                          = undef,
+    $ssl_cert                     = '/etc/pki/dovecot/certs/dovecot.pem',
+    $ssl_key                      = '/etc/pki/dovecot/private/dovecot.pem',
+    $ssl_cipher_list              = undef,
+    $ssl_protocols                = undef,
+    $ssl_dh_parameters_length     = undef,
     # 15-lda.conf
-    $postmaster_address         = undef,
-    $hostname                   = undef,
-    $lda_mail_plugins           = undef,
-    $lda_mail_location          = undef,
-    $lda_mailbox_autocreate     = undef,
-    $lda_mailbox_autosubscribe  = undef,
+    $postmaster_address           = undef,
+    $hostname                     = undef,
+    $lda_mail_plugins             = undef,
+    $lda_mail_location            = undef,
+    $lda_mailbox_autocreate       = undef,
+    $lda_mailbox_autosubscribe    = undef,
     # 20-imap.conf
-    $imap_listen_port            = '*:143',
-    $imaps_listen_port           = '*:993',
-    $imap_mail_plugins          = undef,
-    $imap_client_workarounds    = undef,
+    $imap_listen_port             = '*:143',
+    $imaps_listen_port            = '*:993',
+    $imap_mail_plugins            = undef,
+    $imap_client_workarounds      = undef,
+    $protocol_imap_listen         = true,
     # 20-lmtp.conf
-    $lmtp_mail_plugins          = undef,
-    $lmtp_save_to_detail_mailbox = undef,
+    $lmtp_mail_plugins            = undef,
+    $lmtp_save_to_detail_mailbox  = false,
     # 20-pop3.conf
-    $pop3_mail_plugins          = undef,
-    $pop3_uidl_format           = undef,
-    $pop3_client_workarounds    = undef,
+    $pop3_mail_plugins            = undef,
+    $pop3_uidl_format             = undef,
+    $pop3_client_workarounds      = undef,
     # 20-managesieve.conf
-    $manage_sieve               = undef,
-    $managesieve_service         = false,
-    $managesieve_service_count   = 0,
+    $manage_sieve                 = undef,
+    $managesieve_service          = false,
+    $managesieve_service_count    = 0,
     # 90-sieve.conf
-    $sieve                      = '~/.dovecot.sieve',
-    $sieve_after                = undef,
-    $sieve_before               = undef,
-    $sieve_dir                  = '~/sieve',
-    $sieve_max_actions          = undef,
-    $sieve_max_redirects        = undef,
-    $sieve_max_script_size      = undef,
-    $sieve_quota_max_scripts    = undef,
-    $sieve_quota_max_storage    = undef,
-    $sieve_extensions            = undef,
-    $recipient_delimiter         = undef,
+    $sieve                        = '~/.dovecot.sieve',
+    $sieve_after                  = undef,
+    $sieve_before                 = undef,
+    $sieve_dir                    = '~/sieve',
+    $sieve_global_dir             = undef,
+    $sieve_max_actions            = undef,
+    $sieve_max_redirects          = undef,
+    $sieve_max_script_size        = undef,
+    $sieve_quota_max_scripts      = undef,
+    $sieve_quota_max_storage      = undef,
+    $sieve_extensions             = undef,
+    $recipient_delimiter          = undef,
     # 90-plugin.conf
-    $fts                        = undef,
+    $fts                          = undef,
     # 90-quota.conf
-    $quota                      = undef,
-    $quota_warnings             = [],
+    $quota                        = undef,
+    $quota_warnings               = [],
     # auth-passwdfile.conf.ext
-    $auth_passwdfile_passdb     = undef,
-    $auth_passwdfile_userdb     = undef,
+    $auth_passwdfile_passdb       = undef,
+    $auth_passwdfile_userdb       = undef,
     # auth-sql.conf.ext
-    $auth_sql_userdb_static     = undef,
-    $auth_sql_path              = '/etc/dovecot/dovecot-sql.conf.ext',
+    $auth_sql_userdb_static       = undef,
+    $auth_sql_path                = '/etc/dovecot/dovecot-sql.conf.ext',
     # auth-ldap.conf.ext
-    $auth_ldap_userdb_static    = undef,
-    $auth_master_separator      = '*',
-    $mail_max_userip_connections = 512,
-    $first_valid_uid             = false,
-    $last_valid_uid              = false,
+    $auth_ldap_userdb_static      = undef,
+    $auth_master_separator        = '*',
+    $mail_max_userip_connections  = 512,
+    $first_valid_uid              = false,
+    $last_valid_uid               = false,
 
-    $manage_service              = true,
-    $custom_packages             = undef,
-    $ensure_packages             = 'installed',
+    $manage_service               = true,
+    $custom_packages              = undef,
+    $ensure_packages              = 'installed',
 
-    $ldap_uris                   = undef,
-    $quota_enabled               = false,
-    $acl_enabled                 = false,
-    $replication_enabled         = false,
-    $shared_mailboxes            = false,
-    $options_plugins             = {},
+    $ldap_uris                    = undef,
+    $quota_enabled                = false,
+    $acl_enabled                  = false,
+    $replication_enabled          = false,
+    $shared_mailboxes             = false,
+    $options_plugins              = {},
 ) {
 
     validate_array($plugins)
@@ -151,6 +158,7 @@ class dovecot (
     # 10-auth.conf
     validate_bool($disable_plaintext_auth)
     validate_string($auth_username_chars)
+    validate_string($auth_username_format)
     validate_string($auth_mechanisms)
     validate_array($auth_include)
     # 10-mail.conf
@@ -234,10 +242,10 @@ class dovecot (
     }
 
     case $::operatingsystem {
-    'RedHat', 'CentOS': { 
+    'RedHat', 'CentOS': {
         $directory = '/etc/dovecot'
         $prefix    = 'dovecot'
-    } 
+    }
     /^(Debian|Ubuntu)$/:{
         $directory = '/etc/dovecot'
         $prefix    = 'dovecot'
@@ -326,13 +334,13 @@ class dovecot (
     file { "${directory}/conf.d/20-pop3.conf":
         content => template('dovecot/conf.d/20-pop3.conf.erb'),
     }
-    
+
     if $manage_sieve {
       file { "${directory}/conf.d/20-managesieve.conf":
           content => template('dovecot/conf.d/20-managesieve.conf.erb'),
       }
     }
-    
+
     file { "${directory}/conf.d/90-sieve.conf":
         content => template('dovecot/conf.d/90-sieve.conf.erb'),
     }
@@ -363,4 +371,3 @@ class dovecot (
         content => template('dovecot/conf.d/auth-ldap.conf.ext.erb'),
     }
 }
-

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -9,4 +9,3 @@
 define dovecot::plugin( $prefix = 'dovecot' ) {
     package { "${prefix}-${title}": ensure => installed }
 }
-

--- a/templates/conf.d/10-auth.conf.erb
+++ b/templates/conf.d/10-auth.conf.erb
@@ -32,7 +32,7 @@ disable_plaintext_auth = <%= @disable_plaintext_auth ? 'yes' : 'no' %>
 
 # Default realm/domain to use if none was specified. This is used for both
 # SASL realms and appending @domain to username in plaintext logins.
-#auth_default_realm = 
+#auth_default_realm =
 
 # List of allowed characters in username. If the user-given username contains
 # a character not listed in here, the login automatically fails. This is just
@@ -54,6 +54,9 @@ auth_username_chars = <%= @auth_username_chars %>
 # drop away the domain if it was given, or "%n-AT-%d" would change the '@' into
 # "-AT-". This translation is done after auth_username_translation changes.
 #auth_username_format =
+<% if @auth_username_format -%>
+auth_username_format = <%= @auth_username_format %>
+<% end -%>
 
 # If you want to allow master users to log in by specifying the master
 # username within the normal username string (ie. not using SASL mechanism's
@@ -81,7 +84,7 @@ auth_master_user_separator = <%= @auth_master_separator %>
 # Kerberos keytab to use for the GSSAPI mechanism. Will use the system
 # default (usually /etc/krb5.keytab) if not specified. You may need to change
 # the auth service to run as root to be able to read this file.
-#auth_krb5_keytab = 
+#auth_krb5_keytab =
 
 # Do NTLM and GSS-SPNEGO authentication using Samba's winbind daemon and
 # ntlm_auth helper. <doc/wiki/Authentication/Mechanisms/Winbind.txt>
@@ -96,9 +99,9 @@ auth_master_user_separator = <%= @auth_master_separator %>
 # Require a valid SSL client certificate or the authentication fails.
 #auth_ssl_require_client_cert = no
 
-# Take the username from client's SSL certificate, using 
+# Take the username from client's SSL certificate, using
 # X509_NAME_get_text_by_NID() which returns the subject's DN's
-# CommonName. 
+# CommonName.
 #auth_ssl_username_from_cert = no
 
 # Space separated list of wanted authentication mechanisms:

--- a/templates/conf.d/10-director.conf.erb
+++ b/templates/conf.d/10-director.conf.erb
@@ -11,11 +11,11 @@
 # List of IPs or hostnames to all director servers, including ourself.
 # Ports can be specified as ip:port. The default port is the same as
 # what director service's inet_listener is using.
-#director_servers = 
+#director_servers =
 
 # List of IPs or hostnames to all backend mail servers. Ranges are allowed
 # too, like 10.0.0.10-10.0.0.30.
-#director_mail_servers = 
+#director_mail_servers =
 
 # How long to redirect users to a specific server after it no longer has
 # any connections.
@@ -42,7 +42,7 @@ service director {
     #mode = 0600
   }
   inet_listener {
-    #port = 
+    #port =
   }
 }
 

--- a/templates/conf.d/10-logging.conf.erb
+++ b/templates/conf.d/10-logging.conf.erb
@@ -10,9 +10,15 @@ log_path = <%= @log_path %>
 <% end -%>
 
 # Log file to use for informational messages. Defaults to log_path.
-#info_log_path = 
+#info_log_path =
+<% if @info_log_path -%>
+info_log_path = <%= @info_log_path %>
+<% end -%>
 # Log file to use for debug messages. Defaults to info_log_path.
-#debug_log_path = 
+#debug_log_path =
+<% if @debug_log_path -%>
+debug_log_path = <%= @debug_log_path %>
+<% end -%>
 
 # Syslog facility to use if you're logging to syslog. Usually if you don't
 # want to use "mail", you'll use local0..local7. Also other standard
@@ -62,8 +68,6 @@ plugin {
   #mail_log_events = delete undelete expunge copy mailbox_delete mailbox_rename
   # Group events within a transaction to one line.
   #mail_log_group_events = no
-  # Group events within a transaction to one line.
-  #mail_log_group_events = no
   # Available fields: uid, box, msgid, from, subject, size, vsize, flags
   # size and vsize are available only for expunge and copy events.
   #mail_log_fields = uid box msgid size
@@ -88,7 +92,7 @@ log_timestamp = <%= @log_timestamp -%>
 # Login log format. %$ contains login_log_format_elements string, %s contains
 # the data we want to log.
 #login_log_format = %$: %s
- 
+
 # Log prefix for mail processes. See doc/wiki/Variables.txt for list of
 # possible variables you can use.
 #mail_log_prefix = "%s(%u): "

--- a/templates/conf.d/10-mail.conf.erb
+++ b/templates/conf.d/10-mail.conf.erb
@@ -65,11 +65,11 @@ namespace inbox {
   # Hierarchy separator to use. You should use the same separator for all
   # namespaces or some clients get confused. '/' is usually a good one.
   # The default however depends on the underlying mail storage format.
-  #separator = 
+  #separator =
 
   # Prefix required to access this namespace. This needs to be different for
   # all namespaces. For example "Public/".
-  #prefix = 
+  #prefix =
 
   # Physical location of the mailbox. This is in same format as
   # mail_location, which is also the default for it.
@@ -140,6 +140,16 @@ namespace {
   list = yes
 }
 <%- end %>
+
+<% if !@custom_namespaces.empty? -%>
+<% @custom_namespaces.each_pair do |name, data| -%>
+namespace <%= name %> {
+<% data.each_pair do |key, value| -%>
+  <%= key %> = <%= value %>
+<%- end -%>
+}
+<%- end -%>
+<%- end -%>
 
 # Should shared INBOX be visible as "shared/user" or "shared/user/INBOX"?
 #mail_shared_explicit_inbox = yes
@@ -233,12 +243,12 @@ mail_nfs_index = <%= @mail_nfs_index %>
 # Note that denying root logins is hardcoded to dovecot binary and can't
 # be done even if first_valid_uid is set to 0.
 <%- if @first_valid_uid -%>
-first_valid_uid = <%= @first_valid_uid -%>
+first_valid_uid = <%= @first_valid_uid %>
 <% else -%>
 #first_valid_uid = 500
 <% end -%>
 <%- if @last_valid_uid -%>
-last_valid_uid = <%= @last_valid_uid -%>
+last_valid_uid = <%= @last_valid_uid %>
 <% else -%>
 #last_valid_uid = 0
 <% end %>
@@ -261,7 +271,7 @@ last_valid_uid = <%= @last_valid_uid -%>
 # WARNING: Never add directories here which local users can modify, that
 # may lead to root exploit. Usually this should be done only if you don't
 # allow shell access for users. <doc/wiki/Chrooting.txt>
-#valid_chroot_dirs = 
+#valid_chroot_dirs =
 
 # Default chroot directory for mail processes. This can be overridden for
 # specific users in user database by giving /./ in user's home directory
@@ -269,7 +279,7 @@ last_valid_uid = <%= @last_valid_uid -%>
 # need to do chrooting, Dovecot doesn't allow users to access files outside
 # their mail directory anyway. If your home directories are prefixed with
 # the chroot directory, append "/." to mail_chroot. <doc/wiki/Chrooting.txt>
-#mail_chroot = 
+#mail_chroot =
 
 # UNIX socket path to master authentication server to find users.
 # This is used by imap (for shared users) and lda.
@@ -280,7 +290,7 @@ last_valid_uid = <%= @last_valid_uid -%>
 
 # Space separated list of plugins to load for all services. Plugins specific to
 # IMAP, LDA, etc. are added to this list in their own .conf files.
-#mail_plugins = 
+#mail_plugins =
 <% if @mail_plugins -%>
 mail_plugins = <%= @mail_plugins %>
 <% end -%>
@@ -376,7 +386,7 @@ mbox_write_locks = fcntl
 # fallbacks to re-reading the whole mbox file whenever something in mbox isn't
 # how it's expected to be. The only real downside to this setting is that if
 # some other MUA changes message flags, Dovecot doesn't notice it immediately.
-# Note that a full sync is done with SELECT, EXAMINE, EXPUNGE and CHECK 
+# Note that a full sync is done with SELECT, EXAMINE, EXPUNGE and CHECK
 # commands.
 #mbox_dirty_syncs = yes
 

--- a/templates/conf.d/10-master.conf.erb
+++ b/templates/conf.d/10-master.conf.erb
@@ -32,13 +32,13 @@ service imap-login {
 <% end -%>
   inet_listener imap {
     #port = 143
-<% if @imaplogin_imap_port and @imaplogin_imap_port > 0 -%>
+<% if @imaplogin_imap_port and @imaplogin_imap_port >= 0 -%>
     port = <%= @imaplogin_imap_port %>
-<% end -%>
   }
+<% end -%>
   inet_listener imaps {
     #port = 993
-<% if @imaplogin_imaps_port and @imaplogin_imaps_port > 0 -%>
+<% if @imaplogin_imaps_port and @imaplogin_imaps_port >= 0 -%>
     port = <%= @imaplogin_imaps_port %>
 <% end -%>
     #ssl = yes
@@ -68,6 +68,7 @@ service imap-login {
 <% end -%>
 }
 
+<% if @enable_pop3 -%>
 service pop3-login {
   inet_listener pop3 {
     #port = 110
@@ -83,6 +84,7 @@ service pop3-login {
   process_min_avail = <%= @pop3_login_process_min_avail %>
 <% end -%>
 }
+<% end -%>
 
 service lmtp {
   unix_listener <% if @lmtp_unix_listener -%><%= @lmtp_unix_listener %><% else %>lmtp<% end -%> {
@@ -90,11 +92,11 @@ service lmtp {
 <% if @lmtp_unix_listener_mode -%>
     mode = <%= @lmtp_unix_listener_mode %>
 <% end -%>
-    #user = 
+    #user =
 <% if @lmtp_unix_listener_user -%>
     user = <%= @lmtp_unix_listener_user %>
 <% end -%>
-    #group = 
+    #group =
 <% if @lmtp_unix_listener_group -%>
     group = <%= @lmtp_unix_listener_group %>
 <% end -%>
@@ -104,7 +106,7 @@ service lmtp {
   #inet_listener lmtp {
     # Avoid making LMTP visible for the entire internet
     #address =
-    #port = 
+    #port =
   #}
 <% if @lmtp_socket_path -%>
   unix_listener <%= @lmtp_socket_path %> {
@@ -154,11 +156,11 @@ service auth {
 <% if @auth_listener_userdb_mode -%>
     mode = <%= @auth_listener_userdb_mode %>
 <% end -%>
-    #user = 
+    #user =
 <% if @auth_listener_userdb_user -%>
     user = <%= @auth_listener_userdb_user %>
 <% end -%>
-    #group = 
+    #group =
 <% if @auth_listener_userdb_group -%>
     group = <%= @auth_listener_userdb_group %>
 <% end -%>
@@ -203,7 +205,7 @@ service dict {
   # For example: mode=0660, group=vmail and global mail_access_groups=vmail
   unix_listener dict {
     #mode = 0600
-    #user = 
-    #group = 
+    #user =
+    #group =
   }
 }

--- a/templates/conf.d/10-ssl.conf.erb
+++ b/templates/conf.d/10-ssl.conf.erb
@@ -26,7 +26,7 @@ ssl_key = <<%= @ssl_key %>
 # PEM encoded trusted certificate authority. Set this only if you intend to use
 # ssl_verify_client_cert=yes. The file should contain the CA certificate(s)
 # followed by the matching CRL(s). (e.g. ssl_ca = </etc/ssl/certs/ca.pem)
-#ssl_ca = 
+#ssl_ca =
 
 # Require that CRL check succeeds for client certificates.
 #ssl_require_crl = yes

--- a/templates/conf.d/15-lda.conf.erb
+++ b/templates/conf.d/15-lda.conf.erb
@@ -11,7 +11,7 @@ postmaster_address = <%= @postmaster_address %>
 
 # Hostname to use in various parts of sent mails, eg. in Message-Id.
 # Default is the system's real hostname.
-#hostname = 
+#hostname =
 <% if @hostname -%>
 hostname = <%= @hostname %>
 <% end -%>
@@ -41,7 +41,7 @@ recipient_delimiter = <%= @recipient_delimiter -%>
 <% end %>
 
 # Header where the original recipient address (SMTP's RCPT TO: address) is taken
-# from if not available elsewhere. With dovecot-lda -a parameter overrides this. 
+# from if not available elsewhere. With dovecot-lda -a parameter overrides this.
 # A commonly used header for this is X-Original-To.
 #lda_original_recipient_header =
 

--- a/templates/conf.d/20-imap.conf.erb
+++ b/templates/conf.d/20-imap.conf.erb
@@ -52,17 +52,19 @@ imap_client_workarounds = <%= @imap_client_workarounds %>
 <% end -%>
 
 protocol imap {
+<% if @protocol_imap_listen -%>
   listen = <%= @imap_listen_port %>
-  <%- if @ssl =~ /yes|required/ -%>
-  ssl_listen = <%= @imaps_listen_port -%>
-  <% end %>
+<%- if @ssl =~ /yes|required/ -%>
+  ssl_listen = <%= @imaps_listen_port %>
+<% end -%>
+<% end -%>
   # Maximum number of IMAP connections allowed for a user from each IP address.
   # NOTE: The username is compared case-sensitively.
   #mail_max_userip_connections = 10
   mail_max_userip_connections = <%= @mail_max_userip_connections %>
 
   # Space separated list of plugins to load (default is global mail_plugins).
-  #mail_plugins = $mail_plugins 
+  #mail_plugins = $mail_plugins
 <% if @imap_mail_plugins -%>
   mail_plugins = <%= @imap_mail_plugins %>
 <% end -%>

--- a/templates/conf.d/20-managesieve.conf.erb
+++ b/templates/conf.d/20-managesieve.conf.erb
@@ -49,7 +49,7 @@ service managesieve {
 protocol sieve {
   # Maximum ManageSieve command line length in bytes. ManageSieve usually does
   # not involve overly long command lines, so this setting will not normally need
-  # adjustment 
+  # adjustment
   #managesieve_max_line_length = 65536
 
   # Maximum number of ManageSieve connections allowed for a user from each IP address.
@@ -67,20 +67,20 @@ protocol sieve {
 
   # To fool ManageSieve clients that are focused on CMU's timesieved you can specify
   # the IMPLEMENTATION capability that the dovecot reports to clients.
-  # For example: 'Cyrus timsieved v2.2.13' 
+  # For example: 'Cyrus timsieved v2.2.13'
   #managesieve_implementation_string = Dovecot Pigeonhole
 
   # Explicitly specify the SIEVE and NOTIFY capability reported by the server before
   # login. If left unassigned these will be reported dynamically according to what
   # the Sieve interpreter supports by default (after login this may differ depending
   # on the user).
-  #managesieve_sieve_capability = 
-  #managesieve_notify_capability = 
+  #managesieve_sieve_capability =
+  #managesieve_notify_capability =
 
   # The maximum number of compile errors that are returned to the client upon script
-  # upload or script verification.	
+  # upload or script verification.
   #managesieve_max_compile_errors = 5
 
-  # Refer to 90-sieve.conf for script quota configuration and configuration of 
-  # Sieve execution limits. 
+  # Refer to 90-sieve.conf for script quota configuration and configuration of
+  # Sieve execution limits.
 }

--- a/templates/conf.d/20-pop3.conf.erb
+++ b/templates/conf.d/20-pop3.conf.erb
@@ -88,7 +88,7 @@ protocol pop3 {
   #     Outlook Express and Netscape Mail breaks if end of headers-line is
   #     missing. This option simply sends it if it's missing.
   # The list is space-separated.
-  #pop3_client_workarounds = 
+  #pop3_client_workarounds =
 <% if @pop3_client_workarounds -%>
   pop3_client_workarounds = <%= @pop3_client_workarounds %>
 <% end -%>

--- a/templates/conf.d/90-sieve.conf.erb
+++ b/templates/conf.d/90-sieve.conf.erb
@@ -1,13 +1,13 @@
 ##
 ## Settings for the Sieve interpreter
-## 
+##
 
 # Do not forget to enable the Sieve plugin in 15-lda.conf and 20-lmtp.conf
 # by adding it to the respective mail_plugins= settings.
 
 plugin {
   # The path to the user's main active script. If ManageSieve is used, this the
-  # location of the symbolic link controlled by ManageSieve. 
+  # location of the symbolic link controlled by ManageSieve.
   #sieve = ~/.sieve/dovecot.sieve
 <% if @sieve -%>
   sieve = <%= @sieve %>
@@ -28,7 +28,7 @@ plugin {
   #sieve_default = /var/lib/dovecot/sieve/default.sieve
 
   # Directory for :personal include scripts for the include extension. This
-  # is also where the ManageSieve service stores the user's scripts 
+  # is also where the ManageSieve service stores the user's scripts
   #sieve_dir = ~/.sieve
 <% if @sieve_dir -%>
   sieve_dir = <%= @sieve_dir %>
@@ -36,6 +36,9 @@ plugin {
 
   # Directory for :global include scripts for the include extension.
   #sieve_global_dir =
+<% if @sieve_global_dir -%>
+  sieve_global_dir = <%= @sieve_global_dir %>
+<%- end %>
 
   # Path to a script file or a directory containing script files that need to be
   # executed before the user's script. If the path points to a directory, all

--- a/templates/conf.d/99-replicator.conf.erb
+++ b/templates/conf.d/99-replicator.conf.erb
@@ -24,4 +24,3 @@ service aggregator {
     user = vmail
   }
 }
-

--- a/templates/conf.d/auth-ldap.conf.ext.erb
+++ b/templates/conf.d/auth-ldap.conf.ext.erb
@@ -24,7 +24,7 @@ userdb {
   driver = ldap
   args = <%= @directory %>/dovecot-ldap.conf.ext
 <% end -%>
-  
+
   # Default fields can be used to specify defaults that LDAP may override
   #default_fields = home=/home/virtual/%u
 }

--- a/templates/conf.d/auth-system.conf.ext.erb
+++ b/templates/conf.d/auth-system.conf.ext.erb
@@ -20,7 +20,7 @@ passdb {
 #passdb {
   #driver = passwd
   # [blocking=no]
-  #args = 
+  #args =
 #}
 
 # Shadow passwords for system users (NSS, /etc/shadow or similiar).
@@ -29,7 +29,7 @@ passdb {
 #passdb {
   #driver = shadow
   # [blocking=no]
-  #args = 
+  #args =
 #}
 
 # PAM-like authentication for OpenBSD.
@@ -50,7 +50,7 @@ userdb {
   # <doc/wiki/AuthDatabase.Passwd.txt>
   driver = passwd
   # [blocking=no]
-  #args = 
+  #args =
 }
 
 # Static settings generated from template <doc/wiki/UserDatabase.Static.txt>

--- a/templates/dovecot-dict-auth.conf.ext.erb
+++ b/templates/dovecot-dict-auth.conf.ext.erb
@@ -2,7 +2,7 @@
 # conf.d/auth-dict.conf.ext
 
 # Dictionary URI
-#uri = 
+#uri =
 
 # Default password scheme
 default_pass_scheme = MD5

--- a/templates/dovecot-ldap.conf.ext.erb
+++ b/templates/dovecot-ldap.conf.ext.erb
@@ -15,17 +15,28 @@
 
 # Space separated list of LDAP hosts to use. host:port is allowed too.
 #hosts = localhost powell.vicainne.fr
+<% if @config.key?("hosts") -%>
+hosts = <%= @config["hosts"] %>
+<% end -%>
 
 # LDAP URIs to use. You can use this instead of hosts list. Note that this
 # setting isn't supported by all LDAP libraries.
+<% if defined?(@ldap_uris) -%>
 uris =  <%= @ldap_uris %>
+<% end -%>
 
 # Distinguished Name - the username used to login to the LDAP server.
 # Leave it commented out to bind anonymously (useful with auth_bind=yes).
 #dn =
+<% if @config.key?("dn") -%>
+dn = <%= @config["dn"] %>
+<% end -%>
 
 # Password for LDAP server, if dn is specified.
 #dnpass =
+<% if @config.key?("dnpass") -%>
+dnpass = <%= @config["dnpass"] %>
+<% end -%>
 
 # Use SASL binding instead of the simple binding. Note that this changes
 # ldap_version automatically to be 3 if it's lower. Also note that SASL binds
@@ -40,7 +51,11 @@ uris =  <%= @ldap_uris %>
 #sasl_authz_id =
 
 # Use TLS to connect to the LDAP server.
+<% if @config.key?("tls") -%>
+tls = <%= @config["tls"] %>
+<% else -%>
 tls = yes
+<% end -%>
 # TLS options, currently supported only with OpenLDAP:
 #tls_ca_cert_file =
 #tls_ca_cert_dir =
@@ -58,13 +73,20 @@ tls_require_cert = never
 # -1 = everything. You may need to recompile OpenLDAP with debugging enabled
 # to get enough output.
 #debug_level = 0
+<% if @config.key?("debug_level") -%>
+debug_level = <%= @config["debug_level"] %>
+<% end -%>
 
 # Use authentication binding for verifying password's validity. This works by
 # logging into LDAP server using the username and password given by client.
 # The pass_filter is used to find the DN for the user. Note that the pass_attrs
 # is still used, only the password field is ignored in it. Before doing any
 # search, the binding is switched back to the default DN.
+<% if @config.key?("auth_bind") -%>
+auth_bind = <%= @config["auth_bind"] %>
+<% else -%>
 auth_bind = yes
+<% end -%>
 
 # If authentication binding is used, you can save one LDAP request per login
 # if users' DN can be specified with a common template. The template can use
@@ -80,17 +102,32 @@ auth_bind = yes
 # For example:
 #   auth_bind_userdn = cn=%u,ou=people,o=org
 #
+<% if @config.key?("auth_bind_userdn") -%>
+auth_bind_userdn = <%= @config["auth_bind_userdn"] %>
+<% else -%>
 auth_bind_userdn = uid=%u,ou=People,dc=vicainne,dc=fr
+<% end -%>
 
 # LDAP protocol version to use. Likely 2 or 3.
+<% if @config.key?("ldap_version") -%>
+ldap_version = <%= @config["ldap_version"] %>
+<% else -%>
 ldap_version = 3
+<% end -%>
 
 # LDAP base. %variables can be used here.
 # For example: dc=mail, dc=example, dc=org
+<% if @config.key?("base") -%>
+base = <%= @config["base"] %>
+<% else -%>
 base = dc=vicainne,dc=fr
+<% end -%>
 
 # Dereference: never, searching, finding, always
 #deref = never
+<% if @config.key?("deref") -%>
+deref = <%= @config["deref"] %>
+<% end -%>
 
 # Search scope: base, onelevel, subtree
 scope = subtree
@@ -105,7 +142,11 @@ scope = subtree
 # There are also other special fields which can be returned, see
 # http://wiki.dovecot.org/UserDatabase/ExtraFields
 #user_attrs = homeDirectory=home,uidNumber=uid,gidNumber=gid
+<% if @config.key?("user_attrs") -%>
+user_attrs = <%= @config["user_attrs"] %>
+<% else -%>
 user_attrs = uidNumber=5000,gidNumber=5000,quotaDovecot=quota,mail_plugins
+<% end -%>
 ###user_attrs = homeDirectory=home,uidNumber=5000,gidNumber=5000,quotaDovecot=quota,mail_plugins
 #user_attrs = uidNumber=5000,gidNumber=5000, homeDirectory=home,home=/home/vmail/%u,allow_all_users=yes
 # uid=vmail gid=vmail home=/home/vmail/%u allow_all_users=yes
@@ -115,8 +156,11 @@ user_attrs = uidNumber=5000,gidNumber=5000,quotaDovecot=quota,mail_plugins
 #   %n - user part in user@domain, same as %u if there's no domain
 #   %d - domain part in user@domain, empty if user there's no domain
 #user_filter = (&(objectClass=posixAccount)(uid=%u))
+<% if @config.key?("user_filter") -%>
+user_filter = <%= @config["user_filter"] %>
+<% else -%>
 user_filter = (|(mail=%u)(uid=%u))
-
+<% end -%>
 
 # Password checking attributes:
 #  user: Virtual user name (user@domain), if you wish to change the
@@ -124,7 +168,11 @@ user_filter = (|(mail=%u)(uid=%u))
 #  password: Password, may optionally start with {type}, eg. {crypt}
 # There are also other special fields which can be returned, see
 # http://wiki.dovecot.org/PasswordDatabase/ExtraFields
+<% if @config.key?("pass_attrs") -%>
+pass_attrs = <%= @config["pass_attrs"] %>
+<% else -%>
 pass_attrs = uid=user,userPassword=password
+<% end -%>
 
 # If you wish to avoid two LDAP lookups (passdb + userdb), you can use
 # userdb prefetch instead of userdb ldap in dovecot.conf. In that case you'll
@@ -135,6 +183,9 @@ pass_attrs = uid=user,userPassword=password
 
 # Filter for password lookups
 #pass_filter = (&(objectClass=posixAccount)(uid=%u))
+<% if @config.key?("pass_filter") -%>
+pass_filter = <%= @config["pass_filter"] %>
+<% end -%>
 
 # Attributes and filter to get a list of all users
 iterate_attrs = uid=user
@@ -142,5 +193,8 @@ iterate_filter = (objectClass=posixAccount)
 
 # Default password scheme. "{scheme}" before password overrides this.
 # List of supported schemes is in: http://wiki.dovecot.org/Authentication
+<% if @config.key?("default_pass_scheme") -%>
+default_pass_scheme = <%= @config["default_pass_scheme"] %>
+<% else -%>
 default_pass_scheme = SSHA
-
+<% end -%>

--- a/templates/dovecot-sql.conf.ext.erb
+++ b/templates/dovecot-sql.conf.ext.erb
@@ -29,7 +29,7 @@
 # );
 
 # Database driver: mysql, pgsql, sqlite
-#driver = 
+#driver =
 
 # Database connection string. This is driver-specific setting.
 #
@@ -56,7 +56,7 @@
 #     option_file            - Read options from the given file instead of
 #                              the default my.cnf location
 #     option_group           - Read options from the given group (default: client)
-# 
+#
 #   You can connect to UNIX sockets by using host: host=/var/run/mysql.sock
 #   Note that currently you can't use spaces in parameters.
 #
@@ -95,7 +95,7 @@
 #   %u = entire user@domain
 #   %n = user part of user@domain
 #   %d = domain part of user@domain
-# 
+#
 # Note that these can be used only as input to SQL query. If the query outputs
 # any of these substitutions, they're not touched. Otherwise it would be
 # difficult to have eg. usernames containing '%' characters.

--- a/templates/dovecot.conf.erb
+++ b/templates/dovecot.conf.erb
@@ -22,7 +22,7 @@
 protocols = <%= @protocols %>
 <% end -%>
 
-# A comma separated list of IPs or hosts where to listen in for connections. 
+# A comma separated list of IPs or hosts where to listen in for connections.
 # "*" listens in all IPv4 interfaces, "::" listens in all IPv6 interfaces.
 # If you want to specify non-default ports or anything more complex,
 # edit conf.d/master.conf.
@@ -56,7 +56,7 @@ login_trusted_networks = <%= @login_trusted_networks %>
 <% end -%>
 
 # Sepace separated list of login access check sockets (e.g. tcpwrap)
-#login_access_sockets = 
+#login_access_sockets =
 
 # With proxy_maybe=yes if proxy destination matches any of these IPs, don't do
 # proxying. This isn't necessary normally, but may be useful if the destination

--- a/templates/dovecot.conf.orig
+++ b/templates/dovecot.conf.orig
@@ -19,7 +19,7 @@
 # Protocols we want to be serving.
 #protocols = imap pop3 lmtp
 
-# A comma separated list of IPs or hosts where to listen in for connections. 
+# A comma separated list of IPs or hosts where to listen in for connections.
 # "*" listens in all IPv4 interfaces, "::" listens in all IPv6 interfaces.
 # If you want to specify non-default ports or anything more complex,
 # edit conf.d/master.conf.
@@ -38,7 +38,7 @@
 #login_trusted_networks =
 
 # Sepace separated list of login access check sockets (e.g. tcpwrap)
-#login_access_sockets = 
+#login_access_sockets =
 
 # Show more verbose process titles (in ps). Currently shows user name and
 # IP address. Useful for seeing who are actually using the IMAP processes


### PR DESCRIPTION
* Add auth_username_format config variable (10-auth.conf)
* Add validate_string for auth_username_format
* Remove duplicate lines (10-logging.conf, mail_log_group_events)
* Add more log path settings (10-logging.conf)
* Add custom_namespaces (10-mail.conf)
* Fix newline issues with first_valid_uid and last_valid_uid (10-mail.conf)
* Allow no listen settings in imap protocol section (Obsolete in newer versions) (20-imap.conf)
* Fix default value for lmtp_save_to_detail_mailbox (20-lmtp.conf)
* Add sieve_global_dir setting (90-sieve.conf)
* Change default for ports to "-1". In newer versions of Dovecot, "0" means to *not* listen on that port for that service (init.pp)
* Alignment and spacing fixes where necessary
* Make dovecot-ldap.conf.ext useable as a template through dovecot::file